### PR TITLE
Moved the watcher into the fswatch lib

### DIFF
--- a/fswatch/watch.go
+++ b/fswatch/watch.go
@@ -1,8 +1,9 @@
-package watch
+package fswatch
 
 import (
 	"log"
 	"os"
+	"path"
 	"regexp"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 
 // Watch watches a given path for file system events. It can filter the events it returns based
 // on a regex filter.
-func Watch(path string, filter string, eventc chan *fsnotify.Event, errc chan error) {
+func watch(path string, filter string, eventc chan *fsnotify.Event, errc chan error) {
 
 	fileInfo, err := os.Stat(path)
 	if err != nil {
@@ -66,4 +67,40 @@ func Watch(path string, filter string, eventc chan *fsnotify.Event, errc chan er
 		return
 	}
 	return
+}
+
+// Watcher watches the input file using inotify, knotifyd, etc for CREATE events.
+// Nagios does atomic updates of status.dat by writting out to a temporary file,
+// removing status.dat and moving the temporary file to status.dat. The last
+// event seen in this process is a CREATE, so we use that to kick off reading.
+// Watcher waits on the done chan forever.
+func Watcher(input *string, filec chan *os.File, done chan bool, errc chan error) {
+
+	path := path.Dir(*input)
+
+	dir, err := os.Stat(path)
+
+	if err != nil || !dir.IsDir() {
+		log.Fatalf("Parent directory of input: %s, could not stat or is not a directory, watcher bailing!", path)
+	}
+
+	var eventc = make(chan *fsnotify.Event, 128)
+
+	go func() {
+		for event := range eventc {
+			// TODO: What does this notation actually mean?
+			if event.Op&fsnotify.Create == fsnotify.Create {
+				file, err := os.Open(*input)
+				if err != nil {
+					errc <- err
+				}
+				filec <- file
+			}
+		}
+	}()
+
+	watch(path, *input, eventc, errc)
+
+	//Wait until someone tells us we're done
+	<-done
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/alecthomas/kingpin"
+	"github.com/bensallen/sqlios/fswatch"
 	"github.com/bensallen/sqlios/nagios"
 	"github.com/influxdata/influxdb/client/v2"
 	"github.com/pkg/profile"
@@ -122,11 +123,11 @@ func main() {
 		filec <- file
 	}
 
-	if *oneshot == false {
+	if !*oneshot {
 
 		done := make(chan bool)
 
-		nagios.Watcher(input, filec, done, errc)
+		fswatch.Watcher(input, filec, done, errc)
 
 	}
 


### PR DESCRIPTION
I'd like to limit the `nagios` library to functionality that deals directly with nagios. In this case, we now have a `watch` lib that deals with inotify and various related things for reading the .dat file.